### PR TITLE
Fix interface methods with no return value & cwd on Linux

### DIFF
--- a/cmd/commands/generate.go
+++ b/cmd/commands/generate.go
@@ -19,22 +19,21 @@ var GenerateCmd = &cobra.Command{
 }
 
 func generateRun(cmd *cobra.Command, args []string) {
-	directory := "./..."
+	directory, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
 	if len(args) == 1 {
 		directory = args[0]
 	}
 
-	//// ./... would indicate current working directory
-	//if directory == "./..." {
-	//	directory, _ = os.Getwd()
-	//}
-
 	fmt.Println(fmt.Sprintf("Generating mocks for %s and subdirectories", directory))
 
 	// Iterate files in every child directory compiling Go interfaces to Mocks
-	err := filepath.WalkDir(directory, func(path string, d fs.DirEntry, err error) error {
+	err = filepath.WalkDir(directory, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return err
+			return fmt.Errorf("error walking directory: %w", err)
 		}
 
 		// Ignore non-Go source files and mock files

--- a/cmd/commands/generate.go
+++ b/cmd/commands/generate.go
@@ -63,7 +63,7 @@ func generateRun(cmd *cobra.Command, args []string) {
 			}
 
 			// Create the mock file
-			fileName := strings.ToLower(fmt.Sprintf("%s\\mock_%s.go", currentDir, mock.Name))
+			fileName := fmt.Sprintf("%s_test.go", os.ExpandEnv(filepath.Join(currentDir, mock.Name)))
 			fmt.Println(fmt.Sprintf("Creating file %s", fileName))
 			mockFile, err := os.Create(fileName)
 			if err != nil {

--- a/cmd/commands/generate.go
+++ b/cmd/commands/generate.go
@@ -69,7 +69,6 @@ func generateRun(cmd *cobra.Command, args []string) {
 			if err != nil {
 				_ = mockFile.Close()
 				return fmt.Errorf("error creating file: %w", err)
-
 			}
 
 			// gofmt the mock

--- a/cmd/commands/generate.go
+++ b/cmd/commands/generate.go
@@ -24,10 +24,10 @@ func generateRun(cmd *cobra.Command, args []string) {
 		directory = args[0]
 	}
 
-	// ./... would indicate current working directory
-	if directory == "./..." {
-		directory, _ = os.Getwd()
-	}
+	//// ./... would indicate current working directory
+	//if directory == "./..." {
+	//	directory, _ = os.Getwd()
+	//}
 
 	fmt.Println(fmt.Sprintf("Generating mocks for %s and subdirectories", directory))
 
@@ -47,12 +47,12 @@ func generateRun(cmd *cobra.Command, args []string) {
 
 		f, err := os.Open(path)
 		if err != nil {
-			return err
+			return fmt.Errorf("error opening file: %w", err)
 		}
 
 		mocks, err := imocker.ParseMock(f)
 		if err != nil {
-			return err
+			return fmt.Errorf("error parsing mock: %w", err)
 		}
 
 		// Generate each mock
@@ -60,7 +60,7 @@ func generateRun(cmd *cobra.Command, args []string) {
 			fmt.Println("Iterating mocks")
 			output, err := imocker.GenerateTemplate(mock)
 			if err != nil {
-				return err
+				return fmt.Errorf("error generating template: %w", err)
 			}
 
 			// Create the mock file
@@ -68,21 +68,26 @@ func generateRun(cmd *cobra.Command, args []string) {
 			fmt.Println(fmt.Sprintf("Creating file %s", fileName))
 			mockFile, err := os.Create(fileName)
 			if err != nil {
-				return err
+				_ = mockFile.Close()
+				return fmt.Errorf("error creating file: %w", err)
+
 			}
 
-			//// gofmt the mock
+			// gofmt the mock
 			formattedOutput, err := format.Source([]byte(output))
 			if err != nil {
-				return err
+				_ = mockFile.Close()
+				return fmt.Errorf("error formatting source: %w", err)
 			}
 
 			// Write the mock
 			_, err = mockFile.Write(formattedOutput)
 			if err != nil {
-				return err
+				_ = mockFile.Close()
+				return fmt.Errorf("error writing to sthe mock file: %w", err)
 			}
-			mockFile.Close()
+
+			_ = mockFile.Close()
 		}
 
 		return nil

--- a/imocker/generate.go
+++ b/imocker/generate.go
@@ -7,6 +7,7 @@ import (
 	"go/parser"
 	"go/token"
 	"io"
+	"log"
 	"text/template"
 )
 
@@ -93,6 +94,12 @@ func ParseMock(reader io.Reader) ([]Mock, error) {
 							default:
 								continue
 							}
+						}
+
+						// Skip interfaces with no expected return values
+						if methodTyp.Results == nil || methodTyp.Results.List == nil {
+							log.Println(fmt.Sprintf("No return values %s.%s, skipping", name, method.Names[0].Name))
+							continue
 						}
 
 						for _, ret := range methodTyp.Results.List {

--- a/imocker/generate.go
+++ b/imocker/generate.go
@@ -7,7 +7,6 @@ import (
 	"go/parser"
 	"go/token"
 	"io"
-	"log"
 	"text/template"
 )
 
@@ -68,7 +67,7 @@ func ParseMock(reader io.Reader) ([]Mock, error) {
 				for _, method := range typ.Methods.List {
 
 					// Check for a method else continue
-					switch methodTyp := method.Type.(type) {
+					switch methodType := method.Type.(type) {
 					case *ast.FuncType:
 						mockMethod := Method{
 							NamedParams:    make([]NamedParam, 0),
@@ -77,7 +76,7 @@ func ParseMock(reader io.Reader) ([]Mock, error) {
 							UnNamedReturns: make([]string, 0),
 						}
 
-						for _, param := range methodTyp.Params.List {
+						for _, param := range methodType.Params.List {
 
 							// Check for parameters types else continue
 							switch paramTyp := param.Type.(type) {
@@ -97,12 +96,11 @@ func ParseMock(reader io.Reader) ([]Mock, error) {
 						}
 
 						// Skip interfaces with no expected return values
-						if methodTyp.Results == nil || methodTyp.Results.List == nil {
-							log.Println(fmt.Sprintf("No return values %s.%s, skipping", name, method.Names[0].Name))
+						if methodType.Results == nil || methodType.Results.List == nil {
 							continue
 						}
 
-						for _, ret := range methodTyp.Results.List {
+						for _, ret := range methodType.Results.List {
 
 							// Check for return types else continue
 							switch retTyp := ret.Type.(type) {


### PR DESCRIPTION
**New**
Input argument can now expand environment variables into the file path

**Fixes**
Fixed panic when an interface contains a method and the method has no return values
Properly wrapped errors on various returns
Fixed panic when reading cwd on linux
Fixed file not found errors on case sensitive operating systems